### PR TITLE
Fix duplicate queue population

### DIFF
--- a/commands/queue.py
+++ b/commands/queue.py
@@ -119,7 +119,12 @@ def populate_queue(guild: Guild) -> int:
     queued_role = guild.get_role(QUEUED_ID)
     for member in guild.members:
         if queued_role in member.roles:
-            Queue().queue.append(member)
+            try:
+                Queue().add(member)
+            except AlreadyInQueueException:
+                pass
+            except NoMainRoleException:
+                continue
     len_queue = len(Queue().queue)
     logger.info(f"Queue initialized with {len_queue}")
     return len_queue


### PR DESCRIPTION
Queue population worked through mindlessly appending players to the queue. This could lead to people being in the queue multiple times if `on_ready` was called multiple times, i.e. during reconnects. Instead, use the `add()` method that raises appropriate `AlreadyInQueueException` (and `NoMainRoleException`), and handle them.